### PR TITLE
Update API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -13,7 +13,7 @@ Notable examples:
 
 ## Creating an SST graph from data
 
-See the [example](../src/API_EXAMPLE.go). To make node registration as easy as possible, you can use two functions
+See the [example](../src/API_EXAMPLE_1.go). To make node registration as easy as possible, you can use two functions
 `Vertex()` and `Edge()` to create nodes and links respectively. These names are chosen to distance themselves
 from the underlying `Node` and `Link`naming, by using the more mathematical names for these objects.
 


### PR DESCRIPTION
Fix broken "example" link in docs/API.md from ../src/API_EXAMPLE.go to point to ../src/API_EXAMPLE_1.go

The "Creating an SST graph from data" section referenced a generic 'example without specifying the actual file, resulting in confusion and effectively a 404-like experience for users. This commit clarifies the link to explicitly refer to ../src/API_EXAMPLE_1.go, which matches the code shown in that section.