### PR TITLE
 create type link, truncate instead of drop table for contextdirectory

### DIFF
--- a/pkg/SSTorytime/SSTorytime.go
+++ b/pkg/SSTorytime/SSTorytime.go
@@ -678,6 +678,11 @@ func Configure(ctx PoSST,load_arrows bool) {
 		fmt.Println("Unable to create type as, ",NODEPTR_TYPE)
 		os.Exit(-1)
 	}
+	
+	if !CreateType(ctx,LINK_TYPE) {
+		fmt.Println("Unable to create type as, ",LINK_TYPE)
+		os.Exit(-1)
+	}	
 
 	if !CreateType(ctx,APPOINTMENT_TYPE) {
 		fmt.Println("Unable to create type as, ",APPOINTMENT_TYPE)
@@ -1738,7 +1743,7 @@ func GetContext(contextptr ContextPtr) string {
 
 func UpdateDBContexts(ctx PoSST) {
 
-	ctx.DB.QueryRow("drop table ContextDirectory")
+	ctx.DB.QueryRow("TRUNCATE ContextDirectory")
 
 	for ctxdir := range CONTEXT_DIRECTORY {
 		UploadContextToDB(ctx,CONTEXT_DIRECTORY[ctxdir])


### PR DESCRIPTION
The setup of a new database was failing because the **link** type was not created. I found it was missing.
Also, the contextdirectory table was dropped in the function UpdateDBContexts , and after this call, the contextdirectory relation was not found anymore in the database. I suppose the intented behavior was to truncate the table, not to drop it.
To be reviewed :) 