### PR TITLE
Made dynamic PG_BINDIR fall back if pg_config fails

### DIFF
--- a/contrib/makeramdb.sh
+++ b/contrib/makeramdb.sh
@@ -7,7 +7,14 @@ echo "TRY TO CONFIGURE database with a GNU/Linux ram disk"
 echo ""
 
 if /usr/bin/id postgres > /dev/null; then
-    PG_BINDIR=/usr/bin
+    # Try to get the path from pg_config; mute errors if not found
+    PG_BINDIR=$(pg_config --bindir 2>/dev/null)
+
+    # If PG_BINDIR is empty (pg_config failed), default to /usr/bin
+    if [ -z "$PG_BINDIR" ]; then
+        PG_BINDIR="/usr/bin"
+    fi
+
     sudo chown postgres:postgres /mnt/pg_ram
     echo Stopping existing postgres
     sudo systemctl stop postgresql


### PR DESCRIPTION
This change fixes the issue of pg_config failing, for example if it doesn't
exist in $PATH and falls back to the original default.