### PR TITLE
Fix: copy/paste error in switch NPtr.Class

### DIFF
--- a/pkg/SSTorytime/N4L_parsing.go
+++ b/pkg/SSTorytime/N4L_parsing.go
@@ -156,7 +156,7 @@ func CheckAltCaps(sst *PoSST,event Node,ErrFunc func(string)) {
 	case LT128:
 		for key := range sst.NODE_DIRECTORY.LT128 {
 			
-			keyNPtr.Class = N3GRAM
+			keyNPtr.Class = LT128
 			keyNPtr.CPtr = sst.NODE_DIRECTORY.LT128[key]
 			n := sst.NODE_DIRECTORY.LT128directory[keyNPtr.CPtr]
 			


### PR DESCRIPTION
Hi Mark, I have spotted an obvious recent copy/paste error that crash uploading files, thanks for all you do !